### PR TITLE
Implement config and auth pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# 35mm.am UI
+
+This project is a small React app showing a photo feed with simple authentication pages.
+
+## Setup
+
+```bash
+npm install
+npm start
+```
+
+## Environment variables
+
+- `REACT_APP_API_URL` - base URL for the backend API (defaults to `http://localhost:8080`).
+- `REACT_APP_IMAGE_BASE_URL` - base URL used to build photo image URLs (defaults to `http://post35mm.com/`).
+
+Create a `.env` file or set these variables in your environment when starting the app.
+
+## Available Scripts
+
+- `npm start` – start development server.
+- `npm run build` – create production build.
+
+```bash
+npm start
+```
+
+## Tests
+Run the test suite:
+
+```bash
+npm test
+```

--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,30 @@
 import './App.css';
-import './components/Photo/Photo';
 import { Routes, Route, Outlet, Link } from 'react-router-dom';
 
 import Photos from './containers/Photos/Photos';
 import Header from './layout/Header/Header';
 import { SignUp } from './components/SignUp/SignUp';
+import { SignIn } from './components/SignIn/SignIn';
+import { ForgotPassword } from './components/ForgotPassword/ForgotPassword';
+import { ChangePassword } from './components/ChangePassword/ChangePassword';
+import { Profile } from './components/Profile/Profile';
+import { Settings } from './components/Settings/Settings';
+import { useContext } from 'react';
+import { AuthContext } from './AuthContext';
 
 function App() {
+  const { user } = useContext(AuthContext);
   return (
     <div className="App">
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Photos />} />
           <Route path="signup" element={<SignUp />} />
+          <Route path="signin" element={<SignIn />} />
+          <Route path="forgot-password" element={<ForgotPassword />} />
+          <Route path="change-password" element={<ChangePassword />} />
+          <Route path="profile" element={user ? <Profile /> : <SignIn />} />
+          <Route path="settings" element={user ? <Settings /> : <SignIn />} />
         </Route>
       </Routes>
     </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,21 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthContext } from './AuthContext';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('axios', () => ({
+  get: jest.fn().mockResolvedValue({ data: [] }),
+}));
+
+test('renders 35mm.am header', () => {
+  render(
+    <MemoryRouter>
+      <AuthContext.Provider value={{ user: null, login: jest.fn(), logout: jest.fn() }}>
+        <App />
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+
+  const headerElement = screen.getByText('35mm.am');
+  expect(headerElement).toBeInTheDocument();
 });

--- a/src/AuthContext.js
+++ b/src/AuthContext.js
@@ -1,0 +1,16 @@
+import { createContext, useState } from 'react';
+
+export const AuthContext = createContext({ user: null, login: () => {}, logout: () => {} });
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  const login = (u) => setUser(u);
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/components/ChangePassword/ChangePassword.js
+++ b/src/components/ChangePassword/ChangePassword.js
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { Form } from '../../Styled';
+import { inputState } from '../../forms/Input';
+
+const Container = styled.div`
+  margin: 5em auto;
+  width: 50%;
+`;
+
+export const ChangePassword = () => {
+  const [password1, setPassword1] = useState(new inputState());
+  const [password2, setPassword2] = useState(new inputState());
+
+  return (
+    <Container>
+      <h1>Change Password</h1>
+      <Form.Group>
+        <Form.Label htmlFor="password1">New Password:</Form.Label>
+        <Form.Input id="password1" type="password" onChange={setPassword1} value={password1.value} required />
+      </Form.Group>
+      <Form.Group>
+        <Form.Label htmlFor="password2">Confirm Password:</Form.Label>
+        <Form.Input id="password2" type="password" onChange={setPassword2} value={password2.value} required />
+        {password1.value && password2.value && password1.value !== password2.value && (
+          <Form.FeedBack>Passwords do not match.</Form.FeedBack>
+        )}
+      </Form.Group>
+      <Form.Button>Change Password</Form.Button>
+    </Container>
+  );
+};

--- a/src/components/Comments/Comments.js
+++ b/src/components/Comments/Comments.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+
+export const Comments = ({ photoId }) => {
+  const [comments, setComments] = useState([]);
+
+  useEffect(() => {
+    if (!photoId) return;
+    axios
+      .get(`${API_URL}/photos/${photoId}/comments`)
+      .then((res) => setComments(res.data))
+      .catch(() => setComments([]));
+  }, [photoId]);
+
+  return (
+    <div className="comments">
+      <h3>Comments</h3>
+      {comments.map((c, idx) => (
+        <div key={idx} className="comment">
+          <strong>{c.name}:</strong> {c.comment}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { Form } from '../../Styled';
+import { inputState } from '../../forms/Input';
+
+const Container = styled.div`
+  margin: 5em auto;
+  width: 50%;
+`;
+
+export const ForgotPassword = () => {
+  const [email, setEmail] = useState(new inputState());
+
+  return (
+    <Container>
+      <h1>Forgot Password</h1>
+      <Form.Group>
+        <Form.Label htmlFor="email">Email:</Form.Label>
+        <Form.Input id="email" type="email" onChange={setEmail} value={email.value} required />
+      </Form.Group>
+      <Form.Group>
+        <div className="recaptcha">reCAPTCHA</div>
+      </Form.Group>
+      <Form.Button>Send Reset Link</Form.Button>
+    </Container>
+  );
+};

--- a/src/components/Photo/Photo.css
+++ b/src/components/Photo/Photo.css
@@ -42,6 +42,20 @@
   margin-bottom: 1em;
 }
 
+.photo-actions span {
+  margin: 0 0.5em;
+  cursor: pointer;
+  font-size: 1.5em;
+}
+
+.photo-actions .liked {
+  color: red;
+}
+
+.photo-actions .saved {
+  color: green;
+}
+
 @media screen and (max-width: 1440px) {
   .photo {
     min-width: 33%;

--- a/src/components/Photo/Photo.js
+++ b/src/components/Photo/Photo.js
@@ -1,14 +1,34 @@
 import './Photo.css';
+import { useState } from 'react';
+
+const IMAGE_BASE = process.env.REACT_APP_IMAGE_BASE_URL || 'http://post35mm.com/';
 
 export default function Photo({ photo, onClick }) {
+  const [liked, setLiked] = useState(false);
+  const [saved, setSaved] = useState(false);
+
   return (
     <div className="photo" onClick={() => onClick(photo)}>
       <img
         alt={photo.photoTitle}
-        src={'http://post35mm.com/' + photo.url.orig}
+        src={IMAGE_BASE + photo.url.orig}
       ></img>
       <h2>{photo.photoTitle}</h2>
       <h3>{photo.user.name}</h3>
+      <div className="photo-actions" onClick={(e) => e.stopPropagation()}>
+        <span
+          className={liked ? 'liked' : ''}
+          onClick={() => setLiked(!liked)}
+        >
+          ❤
+        </span>
+        <span
+          className={saved ? 'saved' : ''}
+          onClick={() => setSaved(!saved)}
+        >
+          📝
+        </span>
+      </div>
     </div>
   );
 }

--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { AuthContext } from '../../AuthContext';
+
+export const Profile = () => {
+  const { user } = useContext(AuthContext);
+
+  if (!user) {
+    return <div>Please log in.</div>;
+  }
+
+  return (
+    <div>
+      <h1>Profile</h1>
+      <p>Email: {user.email}</p>
+    </div>
+  );
+};

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import { AuthContext } from '../../AuthContext';
+
+export const Settings = () => {
+  const { user } = useContext(AuthContext);
+
+  if (!user) {
+    return <div>Please log in.</div>;
+  }
+
+  return (
+    <div>
+      <h1>Settings</h1>
+    </div>
+  );
+};

--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -1,0 +1,38 @@
+import { useContext, useState } from 'react';
+import styled from 'styled-components';
+import { Form } from '../../Styled';
+import { inputState } from '../../forms/Input';
+import { AuthContext } from '../../AuthContext';
+
+const Container = styled.div`
+  margin: 5em auto;
+  width: 50%;
+`;
+
+export const SignIn = () => {
+  const [email, setEmail] = useState(new inputState());
+  const [password, setPassword] = useState(new inputState());
+  const { login } = useContext(AuthContext);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login({ email: email.value });
+  };
+
+  return (
+    <Container>
+      <h1>Sign In</h1>
+      <form onSubmit={handleSubmit}>
+        <Form.Group>
+          <Form.Label htmlFor="email">Email:</Form.Label>
+          <Form.Input id="email" type="email" onChange={setEmail} value={email.value} required />
+        </Form.Group>
+        <Form.Group>
+          <Form.Label htmlFor="password">Password:</Form.Label>
+          <Form.Input id="password" type="password" onChange={setPassword} value={password.value} required />
+        </Form.Group>
+        <Form.Button type="submit">Login</Form.Button>
+      </form>
+    </Container>
+  );
+};

--- a/src/containers/Photos/Photos.js
+++ b/src/containers/Photos/Photos.js
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef, Children } from 'react';
 import Modal from '../../components/Modal/Modal';
 import Photo from '../../components/Photo/Photo';
+import { Comments } from '../../components/Comments/Comments';
 import useFetch from '../../hooks/useFetch';
 
 const Photos = () => {
@@ -9,6 +10,8 @@ const Photos = () => {
   const [photo, setPhoto] = useState({});
   const { loading, error, list } = useFetch(page);
   const loader = useRef(null);
+
+  const IMAGE_BASE = process.env.REACT_APP_IMAGE_BASE_URL || 'http://post35mm.com/';
 
   const handleObserver = useCallback((entries) => {
     const target = entries[0];
@@ -50,8 +53,9 @@ const Photos = () => {
           <div className="photo-modal" onClick={toggleModal}>
             <img
               alt={photo.photoTitle}
-              src={'http://post35mm.com/' + photo.url.orig}
+              src={IMAGE_BASE + photo.url.orig}
             ></img>
+            <Comments photoId={photo.photoId} />
           </div>
         </Modal>
       ) : (

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+
 function useFetch(page) {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
@@ -17,7 +19,7 @@ function useFetch(page) {
                 setLoading(true);
                 setError(false);
 
-                const res = await axios.get(`http://localhost:8080/photos`, {
+                const res = await axios.get(`${API_URL}/photos`, {
                     signal: controller.signal,
                     headers: {
                         Range: 'photos=' + (page - 1) * 40 + '-' + 40 * page,

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,15 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider } from './AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/layout/Header/Header.js
+++ b/src/layout/Header/Header.js
@@ -1,5 +1,8 @@
 import './Header.css';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { useContext } from 'react';
+import { AuthContext } from '../../AuthContext';
 
 const StyledHeader = styled.header`
   background-color: black;
@@ -22,12 +25,31 @@ const Button = styled.button`
 `;
 
 export default function Header() {
+  const { user, logout } = useContext(AuthContext);
   return (
     <StyledHeader className="header">
       <h1>35mm.am</h1>
       <div>
-        <Button>Log In</Button>
-        <Button>Sign Up</Button>
+        {user ? (
+          <>
+            <Link to="/profile">
+              <Button>Profile</Button>
+            </Link>
+            <Link to="/settings">
+              <Button>Settings</Button>
+            </Link>
+            <Button onClick={logout}>Logout</Button>
+          </>
+        ) : (
+          <>
+            <Link to="/signin">
+              <Button>Log In</Button>
+            </Link>
+            <Link to="/signup">
+              <Button>Sign Up</Button>
+            </Link>
+          </>
+        )}
       </div>
     </StyledHeader>
   );

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,13 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock IntersectionObserver for tests
+class IntersectionObserverMock {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.IntersectionObserver = IntersectionObserverMock;


### PR DESCRIPTION
## Summary
- make API and image base URLs configurable via env vars
- add basic authentication context and pages
- show sign-in/sign-up or profile/settings in header
- display comments when viewing a photo
- add like/save actions
- document project setup, env vars, and testing instructions
- add header test and IntersectionObserver mock

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688923a7691883299384c81a2782d3e3