### PR TITLE
fix: improve validation and error handling

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -6,6 +6,23 @@ const api = axios.create({
   baseURL: API_URL,
 });
 
+export const getErrorMessage = (err) => {
+  if (err.response) {
+    return err.response.data?.message || 'An error occurred.';
+  } else if (err.request) {
+    return 'Unable to reach the server. Please try again later.';
+  }
+  return err.message;
+};
+
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    err.message = getErrorMessage(err);
+    return Promise.reject(err);
+  }
+);
+
 export const setAuthToken = (token) => {
   if (token) {
     api.defaults.headers.common['Authorization'] = `Bearer ${token}`;

--- a/src/components/ChangePassword/ChangePassword.js
+++ b/src/components/ChangePassword/ChangePassword.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Form } from '../../Styled';
 import { inputState } from '../../forms/Input';
 import { useSearchParams } from 'react-router-dom';
-import api from '../../api/client';
+import api, { getErrorMessage } from '../../api/client';
 
 const Container = styled.div`
   margin: 5em auto;
@@ -27,7 +27,7 @@ export const ChangePassword = () => {
       await api.post('/password/reset', { token, password: password1.value });
       setMessage('Password updated');
     } catch (err) {
-      setMessage('Failed to update password');
+      setMessage(getErrorMessage(err));
     }
   };
 
@@ -37,14 +37,28 @@ export const ChangePassword = () => {
       <form onSubmit={handleSubmit}>
         <Form.Group>
           <Form.Label htmlFor="password1">New Password:</Form.Label>
-          <Form.Input id="password1" type="password" onChange={setPassword1} value={password1.value} required />
+          <Form.Input
+            id="password1"
+            type="password"
+            onChange={setPassword1}
+            value={password1.value}
+            required
+          />
         </Form.Group>
         <Form.Group>
           <Form.Label htmlFor="password2">Confirm Password:</Form.Label>
-          <Form.Input id="password2" type="password" onChange={setPassword2} value={password2.value} required />
-          {password1.value && password2.value && password1.value !== password2.value && (
-            <Form.FeedBack>Passwords do not match.</Form.FeedBack>
-          )}
+          <Form.Input
+            id="password2"
+            type="password"
+            onChange={setPassword2}
+            value={password2.value}
+            required
+          />
+          {password1.value &&
+            password2.value &&
+            password1.value !== password2.value && (
+              <Form.FeedBack>Passwords do not match.</Form.FeedBack>
+            )}
         </Form.Group>
         {message && <div>{message}</div>}
         <Form.Button type="submit">Change Password</Form.Button>

--- a/src/components/ForgotPassword/ForgotPassword.js
+++ b/src/components/ForgotPassword/ForgotPassword.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { Form } from '../../Styled';
 import { inputState } from '../../forms/Input';
-import api from '../../api/client';
+import api, { getErrorMessage } from '../../api/client';
 
 const Container = styled.div`
   margin: 5em auto;
@@ -19,7 +19,7 @@ export const ForgotPassword = () => {
       await api.post('/password/forgot', { emailOrUsername: email.value });
       setMessage('Reset link sent to your email.');
     } catch (err) {
-      setMessage('Could not send reset link.');
+      setMessage(getErrorMessage(err));
     }
   };
 
@@ -29,7 +29,13 @@ export const ForgotPassword = () => {
       <form onSubmit={handleSubmit}>
         <Form.Group>
           <Form.Label htmlFor="email">Email:</Form.Label>
-          <Form.Input id="email" type="email" onChange={setEmail} value={email.value} required />
+          <Form.Input
+            id="email"
+            type="email"
+            onChange={setEmail}
+            value={email.value}
+            required
+          />
         </Form.Group>
         <Form.Group>
           <div className="recaptcha">reCAPTCHA</div>

--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Form } from '../../Styled';
 import { inputState } from '../../forms/Input';
 import { AuthContext } from '../../AuthContext';
-import api from '../../api/client';
+import api, { getErrorMessage } from '../../api/client';
 
 const Container = styled.div`
   margin: 5em auto;
@@ -25,7 +25,7 @@ export const SignIn = () => {
       });
       login({ user: res.data.user, token: res.data.token });
     } catch (err) {
-      setError('Invalid email or password');
+      setError(getErrorMessage(err));
     }
   };
 
@@ -35,11 +35,23 @@ export const SignIn = () => {
       <form onSubmit={handleSubmit}>
         <Form.Group>
           <Form.Label htmlFor="email">Email:</Form.Label>
-          <Form.Input id="email" type="email" onChange={setEmail} value={email.value} required />
+          <Form.Input
+            id="email"
+            type="email"
+            onChange={setEmail}
+            value={email.value}
+            required
+          />
         </Form.Group>
         <Form.Group>
           <Form.Label htmlFor="password">Password:</Form.Label>
-          <Form.Input id="password" type="password" onChange={setPassword} value={password.value} required />
+          <Form.Input
+            id="password"
+            type="password"
+            onChange={setPassword}
+            value={password.value}
+            required
+          />
         </Form.Group>
         {error && <Form.FeedBack>{error}</Form.FeedBack>}
         <Form.Button type="submit">Login</Form.Button>

--- a/src/components/SignUp/SignUp.js
+++ b/src/components/SignUp/SignUp.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import { Form } from '../../Styled';
 import { inputState } from '../../forms/Input';
-import api from '../../api/client';
+import api, { getErrorMessage } from '../../api/client';
 
 const Container = styled.div`
   margin: 5em auto;
@@ -56,7 +56,7 @@ export const SignUp = () => {
       setSuccess(true);
       setError('');
     } catch (err) {
-      setError('Failed to create account');
+      setError(getErrorMessage(err));
     }
   };
 
@@ -88,6 +88,7 @@ export const SignUp = () => {
               value={userName.value}
               type="text"
               id="userName"
+              required
             ></Form.Input>
             {userNameAvailable === false && (
               <Form.FeedBack>Username is taken.</Form.FeedBack>
@@ -104,6 +105,7 @@ export const SignUp = () => {
               value={email.value}
               type="text"
               id="email"
+              required
             ></Form.Input>
             {email.invalid && (email.dirty || email.touched) && (
               <Form.FeedBack>Email is required.</Form.FeedBack>

--- a/src/forms/Input.js
+++ b/src/forms/Input.js
@@ -36,33 +36,36 @@ export const Input = (props) => {
         setValue((prev) => {
           let pristine = prev.pristine,
             dirty = prev.dirty,
-            invalid = prev.invalid,
-            valid = prev.valid,
+            valid = true,
             error = '';
 
-          if (props.required && e.target.value === '') {
+          const value = e.target.value;
+
+          if (props.required && value === '') {
             valid = false;
             error = 'This field is required.';
           } else if (validatorFn) {
-            valid = validatorFn(e.target.value);
-            error = 'This field should contain only alphanumeric symbols.';
+            valid = validatorFn(value);
+            if (!valid) {
+              error = 'This field should contain only alphanumeric symbols.';
+            }
           }
 
-          invalid = !valid;
+          const invalid = !valid;
 
-          if (prev.pristine && e.target.value !== prev.initialValue) {
+          if (prev.pristine && value !== prev.initialValue) {
             pristine = false;
             dirty = true;
           }
 
           return {
             ...prev,
-            value: e.target.value,
+            value,
             pristine,
             dirty,
-            invalid: invalid,
-            valid: valid,
-            error: error,
+            invalid,
+            valid,
+            error,
           };
         });
       }}

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,44 +1,44 @@
 import { useState, useEffect } from 'react';
-import api from '../api/client';
+import api, { getErrorMessage } from '../api/client';
 
 function useFetch(page) {
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(false);
-    const [list, setList] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [list, setList] = useState([]);
 
-    useEffect(() => {
-        if (page === 0) {
-            return;
-        }
+  useEffect(() => {
+    if (page === 0) {
+      return;
+    }
 
-        const controller = new AbortController();
-        const sendQuery = async () => {
-            try {
-                setLoading(true);
-                setError(false);
+    const controller = new AbortController();
+    const sendQuery = async () => {
+      try {
+        setLoading(true);
+        setError(false);
 
-                const res = await api.get('/photos', {
-                    signal: controller.signal,
-                    headers: {
-                        Range: 'photos=' + (page - 1) * 40 + '-' + 40 * page,
-                    },
-                });
+        const res = await api.get('/photos', {
+          signal: controller.signal,
+          headers: {
+            Range: 'photos=' + (page - 1) * 40 + '-' + 40 * page,
+          },
+        });
 
-                setList((prev) => [...new Set([...prev, ...res.data])]);
-                setLoading(false);
-            } catch (err) {
-                setError(err);
-            }
-        };
+        setList((prev) => [...new Set([...prev, ...res.data])]);
+        setLoading(false);
+      } catch (err) {
+        setError(getErrorMessage(err));
+      }
+    };
 
-        sendQuery();
+    sendQuery();
 
-        return () => {
-            controller.abort();
-        };
-    }, [page]);
+    return () => {
+      controller.abort();
+    };
+  }, [page]);
 
-    return { loading, error, list };
+  return { loading, error, list };
 }
 
 export default useFetch;


### PR DESCRIPTION
## Summary
- ensure input fields become valid when filled and add required signup fields
- centralize API error parsing and display server/network messages across forms

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688ab39abe3c8329b167e37aae70d5b3