### PR TITLE
Add photo detail overlay with navigation and routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Photos />} />
+          <Route path="photos/:id" element={<Photos />} />
           <Route path="signup" element={<SignUp />} />
           <Route path="signin" element={<SignIn />} />
           <Route path="forgot-password" element={<ForgotPassword />} />

--- a/src/components/Comments/Comments.js
+++ b/src/components/Comments/Comments.js
@@ -3,6 +3,8 @@ import api from '../../api/client';
 
 export const Comments = ({ photoId }) => {
   const [comments, setComments] = useState([]);
+  const IMAGE_BASE =
+    process.env.REACT_APP_IMAGE_BASE_URL || 'http://post35mm.com/';
 
   useEffect(() => {
     if (!photoId) return;
@@ -17,7 +19,23 @@ export const Comments = ({ photoId }) => {
       <h3>Comments</h3>
       {comments.map((c, idx) => (
         <div key={idx} className="comment">
-          <strong>{c.name}:</strong> {c.comment}
+          {c.user?.avatar && (
+            <img
+              src={IMAGE_BASE + c.user.avatar}
+              alt={c.user?.name || 'commenter'}
+            />
+          )}
+          <div className="comment-body">
+            <div className="comment-header">
+              <strong>{c.user?.name || c.name}</strong>
+              {c.createdAt && (
+                <span className="date">
+                  {new Date(c.createdAt).toLocaleDateString()}
+                </span>
+              )}
+            </div>
+            <div className="comment-text">{c.comment}</div>
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/Photo/Photo.css
+++ b/src/components/Photo/Photo.css
@@ -1,12 +1,104 @@
 .photo-modal {
-  width: 100%;
-  height: calc(100vh - 51px);
-  background-color: rgb(38, 38, 38);
-  position: absolute;
-  top: 51px;
+  position: fixed;
+  top: 0;
   left: 0;
-  text-align: center;
-  padding-top: 60px;
+  width: 100%;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  box-sizing: border-box;
+  padding: 20px;
+  z-index: 1000;
+}
+
+.photo-modal .photo-wrapper {
+  position: relative;
+  max-width: 70%;
+  max-height: 100%;
+}
+
+.photo-modal .photo-wrapper img {
+  max-width: 100%;
+  max-height: 80vh;
+  object-fit: contain;
+}
+
+.photo-modal .nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 2em;
+  cursor: pointer;
+  user-select: none;
+}
+
+.photo-modal .nav.prev {
+  left: 10px;
+}
+
+.photo-modal .nav.next {
+  right: 10px;
+}
+
+.photo-modal .info {
+  width: 30%;
+  margin-left: 20px;
+  overflow-y: auto;
+  max-height: 80vh;
+  position: relative;
+}
+
+.photo-modal .info .close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5em;
+  cursor: pointer;
+}
+
+.photo-modal .author {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.photo-modal .author img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  margin-right: 10px;
+}
+
+.comments {
+  margin-top: 20px;
+}
+
+.comment {
+  display: flex;
+  margin-bottom: 10px;
+}
+
+.comment img {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  margin-right: 8px;
+}
+
+.comment-header {
+  display: flex;
+  flex-direction: column;
+}
+
+.comment-header .date {
+  font-size: 0.8em;
+  color: #bbb;
 }
 .photos {
   display: flex;

--- a/src/containers/Photos/Photos.js
+++ b/src/containers/Photos/Photos.js
@@ -1,15 +1,19 @@
-import { useState, useCallback, useEffect, useRef, Children } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import Modal from '../../components/Modal/Modal';
 import Photo from '../../components/Photo/Photo';
 import { Comments } from '../../components/Comments/Comments';
 import useFetch from '../../hooks/useFetch';
+import api from '../../api/client';
 
 const Photos = () => {
   const [page, setPage] = useState(0);
-  const [showModal, setShowModal] = useState(false);
-  const [photo, setPhoto] = useState({});
+  const [photo, setPhoto] = useState(null);
+  const [index, setIndex] = useState(null);
   const { loading, error, list } = useFetch(page);
   const loader = useRef(null);
+  const navigate = useNavigate();
+  const { id } = useParams();
 
   const IMAGE_BASE = process.env.REACT_APP_IMAGE_BASE_URL || 'http://post35mm.com/';
 
@@ -38,33 +42,112 @@ const Photos = () => {
     return () => observer.unobserve(target);
   }, [handleObserver]);
 
-  const toggleModal = (photo) => {
-    setShowModal(!showModal);
-    setPhoto(photo);
+  const openPhoto = (p, idx) => {
+    setPhoto(p);
+    setIndex(idx);
+    navigate(`/photos/${p.photoId}`);
   };
+
+  const closeModal = () => {
+    navigate('/');
+  };
+
+  const showPrev = (e) => {
+    e.stopPropagation();
+    if (index > 0) {
+      const newIndex = index - 1;
+      const newPhoto = list[newIndex];
+      if (newPhoto) {
+        setPhoto(newPhoto);
+        setIndex(newIndex);
+        navigate(`/photos/${newPhoto.photoId}`);
+      }
+    }
+  };
+
+  const showNext = (e) => {
+    e.stopPropagation();
+    if (index !== null && index < list.length - 1) {
+      const newIndex = index + 1;
+      const newPhoto = list[newIndex];
+      if (!newPhoto) return;
+      setPhoto(newPhoto);
+      setIndex(newIndex);
+      navigate(`/photos/${newPhoto.photoId}`);
+    }
+  };
+
+  useEffect(() => {
+    if (!id) {
+      setPhoto(null);
+      setIndex(null);
+      return;
+    }
+
+    const idx = list.findIndex((p) => String(p.photoId) === id);
+    if (idx !== -1) {
+      setPhoto(list[idx]);
+      setIndex(idx);
+      return;
+    }
+
+    api
+      .get(`/photos/${id}`)
+      .then((res) => setPhoto(res.data))
+      .catch(() => setPhoto(null));
+  }, [id, list]);
 
   return (
     <div className="photos">
       <div ref={loader} />
       {loading && <p>Loading...</p>}
       {error && <p>Error!</p>}
-      {showModal ? (
+      {id && photo ? (
         <Modal>
-          <div className="photo-modal" onClick={toggleModal}>
-            <img
-              alt={photo.photoTitle}
-              src={IMAGE_BASE + photo.url.orig}
-            ></img>
-            <Comments photoId={photo.photoId} />
+          <div className="photo-modal" onClick={closeModal}>
+            <div className="photo-wrapper" onClick={(e) => e.stopPropagation()}>
+              <span className="nav prev" onClick={showPrev}>
+                &#10094;
+              </span>
+              <img alt={photo.photoTitle} src={IMAGE_BASE + photo.url.orig} />
+              <span className="nav next" onClick={showNext}>
+                &#10095;
+              </span>
+            </div>
+            <div className="info" onClick={(e) => e.stopPropagation()}>
+              <button className="close" onClick={closeModal}>
+                &times;
+              </button>
+              <div className="author">
+                {photo.user?.avatar && (
+                  <img
+                    src={IMAGE_BASE + photo.user.avatar}
+                    alt={photo.user.name}
+                  />
+                )}
+                <h3>{photo.user?.name}</h3>
+              </div>
+              <h2>{photo.photoTitle}</h2>
+              {photo.category && <p className="category">{photo.category}</p>}
+              {photo.likes !== undefined && (
+                <p>{photo.likes} people likes this.</p>
+              )}
+              {photo.views !== undefined && <p>{photo.views} Views</p>}
+              {photo.createdAt && (
+                <p>Posted: {new Date(photo.createdAt).toLocaleDateString()}</p>
+              )}
+              {photo.description && <p>{photo.description}</p>}
+              <Comments photoId={photo.photoId} />
+            </div>
           </div>
         </Modal>
       ) : (
-        list.map((photo) => (
+        list.map((p, idx) => (
           <Photo
-            onClick={toggleModal}
-            key={photo.photoId}
-            photo={photo}
-          ></Photo>
+            onClick={(photo) => openPhoto(photo, idx)}
+            key={p.photoId}
+            photo={p}
+          />
         ))
       )}
     </div>


### PR DESCRIPTION
## Summary
- show photo details in modal accessible at /photos/:id
- add prev/next navigation and info panel with author details
- expand comments to include avatars and dates

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688ad12fe5a4832998891d74fda8b1bb