### PR TITLE
Fix feed pagination and abort handling

### DIFF
--- a/src/containers/Photos/Photos.js
+++ b/src/containers/Photos/Photos.js
@@ -18,12 +18,15 @@ const Photos = () => {
   const navigate = useNavigate();
   const { id } = useParams();
 
-  const handleObserver = useCallback((entries) => {
-    const target = entries[0];
-    if (target.isIntersecting) {
-      setPage((prev) => prev + 1);
-    }
-  }, []);
+  const handleObserver = useCallback(
+    (entries) => {
+      const target = entries[0];
+      if (target.isIntersecting && !loading) {
+        setPage((prev) => prev + 1);
+      }
+    },
+    [loading]
+  );
 
   useEffect(() => {
     const option = {
@@ -43,7 +46,7 @@ const Photos = () => {
     return () => {
       if (target) observer.unobserve(target);
     };
-  }, [handleObserver]);
+  }, [handleObserver, loading]);
 
   const openPhoto = (p, idx) => {
     setPhoto(p);

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -28,7 +28,10 @@ function useFetch(page, params = {}) {
         setList((prev) => [...new Set([...prev, ...res.data])]);
         setLoading(false);
       } catch (err) {
-        setError(getErrorMessage(err));
+        if (err.code !== 'ERR_CANCELED') {
+          setError(getErrorMessage(err));
+        }
+        setLoading(false);
       }
     };
 


### PR DESCRIPTION
## Summary
- avoid advancing feed page while previous page is loading
- resubscribe observer on loading state changes
- clear loading and suppress errors for canceled requests

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_688d2ed669b48329a847d78eacdd54a9